### PR TITLE
不存在application.yml时会再去找bootstrap.yml.  支持@FeignClient(path = "sys")和@FeignClient(path = "sys/")  写法,之前只支持 @FeignClient(path = "/sys")

### DIFF
--- a/feignx/build.gradle.kts
+++ b/feignx/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.lyflexi"
-version = "4.1.1"
+version = "4.1.3"
 
 repositories {
     mavenCentral()

--- a/feignx/src/main/java/com/lyflexi/feignx/properties/ConfigReader.java
+++ b/feignx/src/main/java/com/lyflexi/feignx/properties/ConfigReader.java
@@ -24,6 +24,8 @@ public class ConfigReader {
     private static final String PROPERTIES_FILE_NAME = "application.properties";
     private static final String YML_FILE_NAME = "application.yml";
     private static final String YAML_FILE_NAME = "application.yaml";
+    private static final String YML2_FILE_NAME = "bootstrap.yml";
+    private static final String YAML2_FILE_NAME = "bootstrap.yaml";
 
     public static Properties readProperties(PsiDirectory moduleDirectory) {
         return readPropertiesFromFile(moduleDirectory, PROPERTIES_FILE_NAME);
@@ -33,6 +35,12 @@ public class ConfigReader {
         Map<String, Object> yamlData = readYmlFromFile(moduleDirectory, YML_FILE_NAME);
         if (yamlData == null) {
             yamlData = readYmlFromFile(moduleDirectory, YAML_FILE_NAME);
+        }
+        if (yamlData == null) {
+            yamlData = readYmlFromFile(moduleDirectory, YML2_FILE_NAME);
+        }
+        if (yamlData == null) {
+            yamlData = readYmlFromFile(moduleDirectory, YAML2_FILE_NAME);
         }
         return yamlData;
     }

--- a/feignx/src/main/java/com/lyflexi/feignx/utils/JavaSourceFileUtil.java
+++ b/feignx/src/main/java/com/lyflexi/feignx/utils/JavaSourceFileUtil.java
@@ -472,12 +472,24 @@ public class JavaSourceFileUtil {
                 PsiAnnotationMemberValue value = attribute.getValue();
                 if (value instanceof PsiLiteralExpression) {
                     String path = ((PsiLiteralExpression) value).getValue().toString();
-                    return StringUtils.isNotBlank(path) && !path.startsWith("/") ? "/" + path : path;
+                    if(StringUtils.isBlank(path)){
+                        return "";
+                    }
+                    // 如果path不以/开头，添加/
+                    if (!path.startsWith("/")) {
+                        path = "/" + path;
+                    }
+                    // 如果path以/结尾，去除/
+                    if (path.endsWith("/")) {
+                        path = path.substring(0, path.length() - 1);
+                    }
+                    return path;
                 }
             }
         }
         return "";
     }
+
     // 判断类是否带有@FeignClient注解
     private static boolean isFeignInterface(PsiClass psiClass) {
         PsiAnnotation annotation = psiClass.getAnnotation("org.springframework.cloud.openfeign.FeignClient");

--- a/feignx/src/main/java/com/lyflexi/feignx/utils/JavaSourceFileUtil.java
+++ b/feignx/src/main/java/com/lyflexi/feignx/utils/JavaSourceFileUtil.java
@@ -471,7 +471,8 @@ public class JavaSourceFileUtil {
             if ("path".equals(attribute.getName())) {
                 PsiAnnotationMemberValue value = attribute.getValue();
                 if (value instanceof PsiLiteralExpression) {
-                    return ((PsiLiteralExpression) value).getValue().toString();
+                    String path = ((PsiLiteralExpression) value).getValue().toString();
+                    return StringUtils.isNotBlank(path) && !path.startsWith("/") ? "/" + path : path;
                 }
             }
         }


### PR DESCRIPTION
1:不存在application.yml时会再去找bootstrap.yml.  
2:支持@FeignClient(path = "sys")和@FeignClient(path = "sys/")  写法,之前只支持 @FeignClient(path = "/sys")